### PR TITLE
Hide unimplemented config

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingPlugin.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingPlugin.java
@@ -52,7 +52,6 @@ public class TotemFletchingPlugin extends Plugin {
         overlayManager.remove(overlay);
     }
 
-    @Provides
     TotemFletchingConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(TotemFletchingConfig.class);
     }


### PR DESCRIPTION
Hide the config option while there are no options. This is bad UX and is generally flagged during plugin hub review.