### PR TITLE
Added an ent trail animation ID to fix off-screen ent trail rendering issue

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/service/EntTrailService.java
+++ b/src/main/java/com/github/therealguru/totemfletching/service/EntTrailService.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 public class EntTrailService {
 
     private static final List<Integer> ENT_TRAIL_GAME_OBJECT_IDS = List.of(57115, 57116);
-    private static final List<Integer> ENT_TRAIL_INACTIVE_ANIMATION_IDS = List.of(12345);
+    private static final List<Integer> ENT_TRAIL_INACTIVE_ANIMATION_IDS = List.of(12344, 12345);
     private static final List<Integer> ENT_TRAIL_ACTIVE_ANIMATION_IDS = List.of(12346);
 
     private final List<GameObject> entTrails = new ArrayList<>();


### PR DESCRIPTION
There was an issue where the ent trails were not rendering a tile overlay on them because they were off-screen when they were placed. It seems they get an animation ID of 12344 so I just added 12344 to the list of animations:
<img width="660" height="311" alt="Screenshot 2025-07-25 101248" src="https://github.com/user-attachments/assets/8f9475f4-1bff-4df8-92c4-c7c98031caf1" />
