### PR TITLE
fix: allow totem overlays to render independently of text overlays

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
@@ -46,18 +46,19 @@ public class TotemFletchingOverlay extends Overlay {
     }
 
     void renderTotem(Graphics2D graphics2D, Totem totem) {
-        if (!config.renderTextOverlays()) return;
         renderTotemHighlight(graphics2D, totem);
         renderPoints(graphics2D, totem);
 
-        Optional<String> totemText = getTotemText(totem);
-        if (totemText.isPresent()) {
-            String text = totemText.get();
-            Point canvasPoint =
-                    totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, 16);
-            if (canvasPoint != null) {
-                OverlayUtil.renderTextLocation(
-                        graphics2D, canvasPoint, text, config.overlayTextColor());
+        if (config.renderTextOverlays()) {
+            Optional<String> totemText = getTotemText(totem);
+            if (totemText.isPresent()) {
+                String text = totemText.get();
+                Point canvasPoint =
+                        totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, 16);
+                if (canvasPoint != null) {
+                    OverlayUtil.renderTextLocation(
+                            graphics2D, canvasPoint, text, config.overlayTextColor());
+                }
             }
         }
     }


### PR DESCRIPTION
Previously, disabling text overlays prevented all totem overlays from
rendering due to an early return in renderTotem(). Each overlay type
now checks its own config independently:

- Totem highlight: renderTotemOverlays()
- Points: renderPoints()  
- Text: renderTextOverlays()

Repeat of #17 because I didn't write as a branch.