### PR TITLE
Update Config

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -1,13 +1,20 @@
 package com.github.therealguru.totemfletching;
 
+import com.github.therealguru.totemfletching.overlay.TotemFonts;
 import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("totem-fletching")
 public interface TotemFletchingConfig extends Config {
+
+    Color RED = Color.decode("#E45F5F");
+    Color GREEN = Color.decode("#9CF575");
+    Color DEFAULT_TEXT_COLOR = Color.decode("#ddc2ff");
+
     @ConfigSection(
             name = "Overlay Settings",
             description = "Enable or disable individual overlays",
@@ -25,33 +32,43 @@ public interface TotemFletchingConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "renderTotemOverlays",
-            name = "Show Totem Overlays",
-            description = "Draw the overlay over totems",
+            keyName = "renderTotemHighlight",
+            name = "Show Totem Highlight",
+            description = "Draw the highlight over totems",
             section = sectionOverlays,
             position = 1)
-    default boolean renderTotemOverlays() {
+    default boolean renderTotemHighlight() {
         return true;
     }
 
     @ConfigItem(
-            keyName = "renderTextOverlays",
-            name = "Show Totem Text Overlays",
+            keyName = "renderTotemText",
+            name = "Show Totem Text Overlay",
             description =
-                    "Draw the text overlay over totems for animals and total points for the site",
+                    "Draw the text overlay over totems for animals and decorations",
             section = sectionOverlays,
             position = 2)
-    default boolean renderTextOverlays() {
+    default boolean renderTotemText() {
         return true;
     }
 
     @ConfigItem(
-            keyName = "renderPoints",
-            name = "Show Points Overlay",
-            description = "Draw the overlay over totems",
+            keyName = "keepDecoratedText",
+            name = "Keep Fully Decorated Text",
+            description = "Show the text on a fully decorated totem",
             section = sectionOverlays,
             position = 3)
-    default boolean renderPoints() {
+    default boolean keepDecoratedText() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "renderPointsText",
+            name = "Show Points Text Overlay",
+            description = "Draw the text overlay over points",
+            section = sectionOverlays,
+            position = 4)
+    default boolean renderPointsText() {
         return true;
     }
 
@@ -61,7 +78,7 @@ public interface TotemFletchingConfig extends Config {
             description =
                     "Whether to show the ent trails that need to be stepped on for bonus points",
             section = sectionOverlays,
-            position = 4)
+            position = 5)
     default boolean renderEntTrails() {
         return true;
     }
@@ -73,33 +90,65 @@ public interface TotemFletchingConfig extends Config {
     String sectionColors = "sectionColors";
 
     @ConfigItem(
-            keyName = "overlayTextColor",
-            name = "Overlay Text",
-            description = "Choose the color used for the text on the totem overlays",
+            keyName = "carvingInterfaceColor",
+            name = "Carving Highlight Color",
+            description =
+                    "Choose the color used to highlight the correct actions in the carving UI",
             section = sectionColors,
             position = 0)
-    default Color overlayTextColor() {
-        return Color.decode("#ddc2ff");
+    default Color carvingInterfaceColor() {
+        return Color.decode("#9CF575");
     }
 
     @ConfigItem(
             keyName = "totemCompleteColor",
             name = "Completed Totem",
-            description = "Choose the color used for the overlay on completed totems",
+            description = "Choose the color used for the highlight on completed totems",
             section = sectionColors,
             position = 1)
     default Color totemCompleteColor() {
-        return Color.decode("#9CF575");
+        return GREEN;
     }
 
     @ConfigItem(
             keyName = "totemIncompleteColor",
             name = "Incomplete Totem",
-            description = "Choose the color used for the overlay on incomplete totems",
+            description = "Choose the color used for the highlight on incomplete totems",
             section = sectionColors,
             position = 2)
     default Color totemIncompleteColor() {
-        return Color.decode("#E45F5F");
+        return RED;
+    }
+
+    @ConfigItem(
+            keyName = "totemTextColor",
+            name = "Totem Text",
+            description = "Choose the color used for the text on the totem overlays",
+            section = sectionColors,
+            position = 3)
+    default Color totemTextColor() {
+        return DEFAULT_TEXT_COLOR;
+    }
+
+    @ConfigItem(
+            keyName = "pointsTextColor",
+            name = "Points Text",
+            description = "Choose the color used for the text on the points overlays",
+            section = sectionColors,
+            position = 4)
+    default Color pointsTextColor() {
+        return DEFAULT_TEXT_COLOR;
+    }
+
+    @ConfigItem(
+            keyName = "pointsCappedColor",
+            name = "Points at Maximum Color",
+            description =
+                    "Choose the color used to highlight the points tile if the maximum point total has been reached",
+            section = sectionColors,
+            position = 5)
+    default Color pointsCappedColor() {
+        return RED;
     }
 
     @ConfigItem(
@@ -107,19 +156,67 @@ public interface TotemFletchingConfig extends Config {
             name = "Ent Trail Color",
             description = "Choose the color used to draw ent trails",
             section = sectionColors,
-            position = 3)
+            position = 6)
     default Color entTrailColor() {
         return Color.decode("#e4fff6");
     }
 
+    @ConfigSection(
+            name = "Text Settings",
+            description = "Customize the overlay text",
+            position = 2)
+    String sectionText = "sectionText";
+
     @ConfigItem(
-            keyName = "carvingInterfaceColor",
-            name = "Carving Highlight Color",
-            description =
-                    "Choose the color used to highlight the correct actions in the carving UI",
-            section = sectionColors,
+            keyName = "unbuiltHeight",
+            name = "Unbuilt Height",
+            description = "Choose the height of an unbuilt totem text",
+            section = sectionText,
+            position = 0)
+    @Range(max = 500)
+    default int unbuiltHeight() {
+        return 16;
+    }
+
+    @ConfigItem(
+            keyName = "builtHeight",
+            name = "Built Height",
+            description = "Choose the height of a built totem text",
+            section = sectionText,
+            position = 1)
+    @Range(max = 500)
+    default int builtHeight() {
+        return 16;
+    }
+
+    @ConfigItem(
+            keyName = "pointsHeight",
+            name = "Points Height",
+            description = "Choose the height of the points text",
+            section = sectionText,
+            position = 2)
+    @Range(max = 500)
+    default int pointsHeight() {
+        return 16;
+    }
+
+    @ConfigItem(
+            keyName = "overlayFont",
+            name = "Overlay Font",
+            description = "Choose the font type to be used for the overlay text",
+            section = sectionText,
+            position = 3)
+    default TotemFonts overlayFont() {
+        return TotemFonts.RUNESCAPE;
+    }
+
+    @ConfigItem(
+            keyName = "useBoldFont",
+            name = "Bold Style",
+            description = "Use Bold font style instead",
+            section = sectionText,
             position = 4)
     default Color carvingInterfaceColor() {
-        return Color.decode("#9CF575");
+        return GREEN;
     }
 }

--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -7,6 +7,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("totem-fletching")
 public interface TotemFletchingConfig extends Config {
@@ -170,9 +171,10 @@ public interface TotemFletchingConfig extends Config {
     @ConfigItem(
             keyName = "unbuiltHeight",
             name = "Unbuilt Height",
-            description = "Choose the height of an unbuilt totem text",
+            description = "Choose how high the unbuilt totem text will be from the ground",
             section = sectionText,
             position = 0)
+    @Units(Units.PIXELS)
     @Range(max = 500)
     default int unbuiltHeight() {
         return 16;
@@ -181,20 +183,32 @@ public interface TotemFletchingConfig extends Config {
     @ConfigItem(
             keyName = "builtHeight",
             name = "Built Height",
-            description = "Choose the height of a built totem text",
+            description = "Choose how high the built totem text will be from the ground",
             section = sectionText,
             position = 1)
+    @Units(Units.PIXELS)
     @Range(max = 500)
     default int builtHeight() {
         return 16;
     }
 
     @ConfigItem(
-            keyName = "pointsHeight",
-            name = "Points Height",
-            description = "Choose the height of the points text",
+            keyName = "showZeroPoints",
+            name = "Show Zero Points",
+            description = "Show the points text even if the points are zero",
             section = sectionText,
             position = 2)
+    default boolean showZeroPoints() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "pointsHeight",
+            name = "Points Height",
+            description = "Choose how high the points text will be from the ground",
+            section = sectionText,
+            position = 3)
+    @Units(Units.PIXELS)
     @Range(max = 500)
     default int pointsHeight() {
         return 16;
@@ -205,7 +219,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Overlay Font",
             description = "Choose the font type to be used for the overlay text",
             section = sectionText,
-            position = 3)
+            position = 4)
     default TotemFonts overlayFont() {
         return TotemFonts.RUNESCAPE;
     }
@@ -215,8 +229,30 @@ public interface TotemFletchingConfig extends Config {
             name = "Bold Style",
             description = "Use Bold font style instead",
             section = sectionText,
-            position = 4)
-    default Color carvingInterfaceColor() {
-        return GREEN;
+            position = 5)
+    default boolean useBoldFont() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "totemFontSize",
+            name = "Totem Font Size",
+            description = "Font size of the text on the totem",
+            section = sectionText,
+            position = 6)
+    @Range(min = 8, max = 40)
+    default int totemFontSize() {
+        return 16;
+    }
+
+    @ConfigItem(
+            keyName = "pointsFontSize",
+            name = "Points Font Size",
+            description = "Font size of the points text",
+            section = sectionText,
+            position = 7)
+    @Range(min = 8, max = 40)
+    default int pointsFontSize() {
+        return 16;
     }
 }

--- a/src/main/java/com/github/therealguru/totemfletching/model/Totem.java
+++ b/src/main/java/com/github/therealguru/totemfletching/model/Totem.java
@@ -8,6 +8,8 @@ import net.runelite.api.GameObject;
 @Data
 public class Totem {
 
+    private static final int MAXIMUM_POINTS = 15000;
+
     private int totemId;
     private int totemGameObjectId;
     private int pointsGameObjectId;
@@ -66,5 +68,9 @@ public class Totem {
 
     public boolean isRenderable() {
         return totemGameObject != null && pointsGameObject != null;
+    }
+
+    public boolean isPointCapped() {
+        return points >= MAXIMUM_POINTS;
     }
 }

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
@@ -54,16 +54,10 @@ public class TotemFletchingOverlay extends Overlay {
         if (config.renderTotemText()) {
             Optional<String> totemText = getTotemText(totem);
             if (totemText.isPresent()) {
-                String text = totemText.get();
                 Font font = new Font(config.overlayFont().toString(), config.useBoldFont() ? Font.BOLD : Font.PLAIN, config.totemFontSize());
                 graphics2D.setFont(font);
-                Point canvasPoint;
-                if (totem.hasTotemStarted()) {
-                    canvasPoint = totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, config.builtHeight());
-                }
-                else {
-                    canvasPoint = totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, config.unbuiltHeight());
-                }
+                String text = totemText.get();
+                Point canvasPoint = getCanvasPoint(graphics2D, totem, text);
                 if (canvasPoint != null) {
                     OverlayUtil.renderTextLocation(
                             graphics2D, canvasPoint, text, config.totemTextColor());
@@ -114,7 +108,7 @@ public class TotemFletchingOverlay extends Overlay {
     }
 
     void renderPointsOverlay(Graphics2D graphics2D, Totem totem) {
-        if (!config.renderPoints() || totem.getPoints() == 0) return;
+        if (!config.renderPoints() || (totem.getPoints() == 0 && !config.showZeroPoints())) return;
 
         renderPointsText(graphics2D, totem);
         renderPointsTile(graphics2D, totem);
@@ -126,8 +120,10 @@ public class TotemFletchingOverlay extends Overlay {
                 LocalPoint.fromWorld(client.getTopLevelWorldView(), gameObject.getWorldLocation());
         if (localPoint == null) return;
 
+        Font font = new Font(config.overlayFont().toString(), config.useBoldFont() ? Font.BOLD : Font.PLAIN, config.pointsFontSize());
+        graphics2D.setFont(font);
         String text = getPointsText(totem);
-        Point canvasPoint = gameObject.getCanvasTextLocation(graphics2D, text, 16);
+        Point canvasPoint = gameObject.getCanvasTextLocation(graphics2D, text, config.pointsHeight());
         if (canvasPoint == null) return;
 
         OverlayUtil.renderTextLocation(graphics2D, canvasPoint, text, config.overlayTextColor());
@@ -142,5 +138,13 @@ public class TotemFletchingOverlay extends Overlay {
 
     private String getPointsText(Totem totem) {
         return totem.isPointCapped() ? "MAXIMUM" : Integer.toString(totem.getPoints());
+    }
+
+    private Point getCanvasPoint(Graphics2D graphics2D, Totem totem, String text) {
+        if (totem.hasTotemStarted()) {
+            return totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, config.builtHeight());
+        } else {
+            return totem.getTotemGameObject().getCanvasTextLocation(graphics2D, text, config.unbuiltHeight());
+        }
     }
 }

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFonts.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFonts.java
@@ -1,0 +1,24 @@
+package com.github.therealguru.totemfletching.overlay;
+
+import lombok.Getter;
+
+@Getter
+public enum TotemFonts {
+    RUNESCAPE("RuneScape"),
+    REGULAR("RS Regular"),
+    ARIAL("Arial"),
+    TIMES_NEW_ROMAN("Times New Roman"),
+    VERDANA("Verdana"),
+    CAMBRIA("Cambria"),
+    ROCKWELL("Rockwell");
+
+    private final String fontName;
+
+    public String toString() {
+        return this.fontName;
+    }
+
+    TotemFonts(String fontName) {
+        this.fontName = fontName;
+    }
+}


### PR DESCRIPTION
1. Added a Text Settings config section which allows for:
- Customizing the Built and Unbuilt totem text height.
- Points height.
- Text font type.
- Bold or regular style.
- Seperate totem font and points font size.
2. Added an option to allow keeping the text on the totem after it has been decorated 4/4 (default off).
3. Changed the names/descriptions of some config options for better consistency.
4. Ordered the config options a bit better.

This will also resolve Issue #25.