### PR TITLE
Update the config and add border width option

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -1,7 +1,13 @@
 package com.github.therealguru.totemfletching;
 
 import java.awt.Color;
-import net.runelite.client.config.*;
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("totem-fletching")
 public interface TotemFletchingConfig extends Config {
@@ -17,31 +23,11 @@ public interface TotemFletchingConfig extends Config {
     String sectionOverlays = "sectionOverlays";
 
     @ConfigItem(
-            keyName = "renderChatboxOptions",
-            name = "Highlight Correct Chatbox Carving Options",
-            description = "Highlights which animals to select in the Totem Carving UI",
-            section = sectionOverlays,
-            position = 0)
-    default boolean highlightCorrectCarvingChoice() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "maskIncorrectCarvingChoice",
-            name = "Highlight Correct Carving Choices",
-            description = "Whether to mask the incorrect carving choices in the interface",
-            section = sectionOverlays,
-            position = 1)
-    default boolean maskIncorrectCarvingChoice() {
-        return true;
-    }
-
-    @ConfigItem(
             keyName = "renderTotemHighlight",
             name = "Show Totem Highlight",
             description = "Draw the highlight over totems",
             section = sectionOverlays,
-            position = 2)
+            position = 0)
     default boolean renderTotemHighlight() {
         return true;
     }
@@ -51,7 +37,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Show Totem Text Overlay",
             description = "Draw the text overlay over totems for animals and decorations",
             section = sectionOverlays,
-            position = 3)
+            position = 1)
     default boolean renderTotemText() {
         return true;
     }
@@ -61,18 +47,8 @@ public interface TotemFletchingConfig extends Config {
             name = "Show Points Text Overlay",
             description = "Draw the text overlay over points",
             section = sectionOverlays,
-            position = 4)
+            position = 2)
     default boolean renderPoints() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "showZeroPoints",
-            name = "Show Zero Points",
-            description = "Show the points text even if the points are zero",
-            section = sectionAdditional,
-            position = 5)
-    default boolean showZeroPoints() {
         return true;
     }
 
@@ -82,8 +58,28 @@ public interface TotemFletchingConfig extends Config {
             description =
                     "Whether to show the ent trails that need to be stepped on for bonus points",
             section = sectionOverlays,
-            position = 6)
+            position = 3)
     default boolean renderEntTrails() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "highlightCorrectCarvingChoice",
+            name = "Highlight Correct Carving Choices",
+            description = "Highlight which animals to select in the totem carving interface",
+            section = sectionOverlays,
+            position = 4)
+    default boolean highlightCorrectCarvingChoice() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "maskIncorrectCarvingChoice",
+            name = "Mask Incorrect Carving Choices",
+            description = "Mask the incorrect carving choices in the totem carving interface",
+            section = sectionOverlays,
+            position = 5)
+    default boolean maskIncorrectCarvingChoice() {
         return true;
     }
 
@@ -158,20 +154,32 @@ public interface TotemFletchingConfig extends Config {
             keyName = "carvingInterfaceColor",
             name = "Carving Highlight Color",
             description =
-                    "Choose the color used to highlight the correct actions in the carving UI",
+                    "Choose the color used to highlight the correct actions in the carving interface",
             section = sectionColors,
             position = 6)
     default Color carvingInterfaceColor() {
         return Color.decode("#9CF575");
     }
 
-    @Alpha
+    @ConfigItem(
+            keyName = "carvingInterfaceBorderWith",
+            name = "Carving Highlight Border Width",
+            description = "Select the border width for the correct actions",
+            section = sectionColors,
+            position = 7)
+    @Units(Units.PIXELS)
+    @Range(min = 1, max = 10)
+    default int carvingInterfaceBorderWith() {
+        return 2;
+    }
+
     @ConfigItem(
             keyName = "carvingInterfaceMask",
             name = "Carving Mask Color",
-            description = "Choose the color to mask invalid options for carving totems",
+            description = "Choose the color to mask the incorrect actions in the carving interface",
             section = sectionColors,
-            position = 7)
+            position = 8)
+    @Alpha
     default Color carvingMaskColor() {
         return new Color(64, 64, 64, 204);
     }
@@ -194,11 +202,21 @@ public interface TotemFletchingConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "showZeroPoints",
+            name = "Show Zero Points",
+            description = "Show the points text even if the points are zero",
+            section = sectionAdditional,
+            position = 1)
+    default boolean showZeroPoints() {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "unbuiltOffset",
             name = "Unbuilt Totem Offset",
             description = "Choose how high the unbuilt totem text will be from the ground",
             section = sectionAdditional,
-            position = 1)
+            position = 2)
     @Units(Units.PIXELS)
     @Range(max = 800)
     default int unbuiltOffset() {
@@ -210,7 +228,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Built Totem Offset",
             description = "Choose how high the built totem text will be from the ground",
             section = sectionAdditional,
-            position = 2)
+            position = 3)
     @Units(Units.PIXELS)
     @Range(max = 800)
     default int builtOffset() {
@@ -222,7 +240,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Points Offset",
             description = "Choose how high the points text will be from the ground",
             section = sectionAdditional,
-            position = 3)
+            position = 4)
     @Units(Units.PIXELS)
     @Range(max = 800)
     default int pointsOffset() {

--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -162,14 +162,14 @@ public interface TotemFletchingConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "carvingInterfaceBorderWith",
+            keyName = "carvingInterfaceBorderWidth",
             name = "Carving Highlight Border Width",
             description = "Select the border width for the correct choices",
             section = sectionColors,
             position = 7)
     @Units(Units.PIXELS)
     @Range(min = 1, max = 10)
-    default int carvingInterfaceBorderWith() {
+    default int carvingInterfaceBorderWidth() {
         return 2;
     }
 

--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -151,30 +151,30 @@ public interface TotemFletchingConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "carvingInterfaceColor",
+            keyName = "carvingHighlightColor",
             name = "Carving Highlight",
             description =
                     "Choose the color used to highlight the correct choices in the carving interface",
             section = sectionColors,
             position = 6)
-    default Color carvingInterfaceColor() {
+    default Color carvingHighlightColor() {
         return Color.decode("#9CF575");
     }
 
     @ConfigItem(
-            keyName = "carvingInterfaceBorderWidth",
+            keyName = "carvingHighlightBorderWidth",
             name = "Carving Highlight Border Width",
             description = "Select the border width for the correct choices",
             section = sectionColors,
             position = 7)
     @Units(Units.PIXELS)
     @Range(min = 1, max = 10)
-    default int carvingInterfaceBorderWidth() {
+    default int carvingHighlightBorderWidth() {
         return 2;
     }
 
     @ConfigItem(
-            keyName = "carvingInterfaceMask",
+            keyName = "carvingMaskColor",
             name = "Carving Mask",
             description = "Choose the color to mask the incorrect choices in the carving interface",
             section = sectionColors,

--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -34,7 +34,7 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "renderTotemText",
-            name = "Show Totem Text Overlay",
+            name = "Show Totem Text",
             description = "Draw the text overlay over totems for animals and decorations",
             section = sectionOverlays,
             position = 1)
@@ -44,7 +44,7 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "renderPoints",
-            name = "Show Points Text Overlay",
+            name = "Show Points Text",
             description = "Draw the text overlay over points",
             section = sectionOverlays,
             position = 2)
@@ -76,7 +76,7 @@ public interface TotemFletchingConfig extends Config {
     @ConfigItem(
             keyName = "maskIncorrectCarvingChoice",
             name = "Mask Incorrect Carving Choices",
-            description = "Mask the incorrect carving choices in the totem carving interface",
+            description = "Mask the incorrect animals in the totem carving interface",
             section = sectionOverlays,
             position = 5)
     default boolean maskIncorrectCarvingChoice() {
@@ -91,8 +91,8 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "totemCompleteColor",
-            name = "Completed Totem",
-            description = "Choose the color used for the highlight on completed totems",
+            name = "Complete Totem",
+            description = "Choose the color used for the highlight on complete totems",
             section = sectionColors,
             position = 0)
     default Color totemCompleteColor() {
@@ -131,7 +131,7 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "pointsCappedColor",
-            name = "Points at Maximum Color",
+            name = "Points Tile at Maximum",
             description =
                     "Choose the color used to highlight the points tile if the maximum point total has been reached",
             section = sectionColors,
@@ -142,7 +142,7 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "entTrailColor",
-            name = "Ent Trail Color",
+            name = "Ent Trail",
             description = "Choose the color used to draw ent trails",
             section = sectionColors,
             position = 5)
@@ -152,9 +152,9 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "carvingInterfaceColor",
-            name = "Carving Highlight Color",
+            name = "Carving Highlight",
             description =
-                    "Choose the color used to highlight the correct actions in the carving interface",
+                    "Choose the color used to highlight the correct choices in the carving interface",
             section = sectionColors,
             position = 6)
     default Color carvingInterfaceColor() {
@@ -164,7 +164,7 @@ public interface TotemFletchingConfig extends Config {
     @ConfigItem(
             keyName = "carvingInterfaceBorderWith",
             name = "Carving Highlight Border Width",
-            description = "Select the border width for the correct actions",
+            description = "Select the border width for the correct choices",
             section = sectionColors,
             position = 7)
     @Units(Units.PIXELS)
@@ -175,8 +175,8 @@ public interface TotemFletchingConfig extends Config {
 
     @ConfigItem(
             keyName = "carvingInterfaceMask",
-            name = "Carving Mask Color",
-            description = "Choose the color to mask the incorrect actions in the carving interface",
+            name = "Carving Mask",
+            description = "Choose the color to mask the incorrect choices in the carving interface",
             section = sectionColors,
             position = 8)
     @Alpha

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
@@ -69,7 +69,7 @@ public class CarvingActionOverlay extends Overlay {
         if (bounds != null) {
             if (correctChoice && config.highlightCorrectCarvingChoice()) {
                 graphics.setColor(config.carvingInterfaceColor());
-                graphics.setStroke(new BasicStroke(2));
+                graphics.setStroke(new BasicStroke(config.carvingInterfaceBorderWith()));
                 graphics.draw(bounds);
             } else if (!correctChoice && config.maskIncorrectCarvingChoice()) {
                 graphics.setColor(config.carvingMaskColor());

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
@@ -69,7 +69,7 @@ public class CarvingActionOverlay extends Overlay {
         if (bounds != null) {
             if (correctChoice && config.highlightCorrectCarvingChoice()) {
                 graphics.setColor(config.carvingInterfaceColor());
-                graphics.setStroke(new BasicStroke(config.carvingInterfaceBorderWith()));
+                graphics.setStroke(new BasicStroke(config.carvingInterfaceBorderWidth()));
                 graphics.draw(bounds);
             } else if (!correctChoice && config.maskIncorrectCarvingChoice()) {
                 graphics.setColor(config.carvingMaskColor());

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/CarvingActionOverlay.java
@@ -68,8 +68,8 @@ public class CarvingActionOverlay extends Overlay {
         Rectangle bounds = childWidget.getBounds();
         if (bounds != null) {
             if (correctChoice && config.highlightCorrectCarvingChoice()) {
-                graphics.setColor(config.carvingInterfaceColor());
-                graphics.setStroke(new BasicStroke(config.carvingInterfaceBorderWidth()));
+                graphics.setColor(config.carvingHighlightColor());
+                graphics.setStroke(new BasicStroke(config.carvingHighlightBorderWidth()));
                 graphics.draw(bounds);
             } else if (!correctChoice && config.maskIncorrectCarvingChoice()) {
                 graphics.setColor(config.carvingMaskColor());


### PR DESCRIPTION
- Reorganized the config a bit for consistency with other options.
- Changed some names and removed some redundant parts from them.
- Changed some descriptions.
- Added an option to change the border width of the carving highlight, min 1px max 10px.
- Refactored some keyNames and default function names for the carving interface options.

Here is how the changed config looks like by default, but I'm not sure whether it's better to move the border width option into Additional Settings or keep it in Color Settings.
<img width="234" height="620" alt="newconfig" src="https://github.com/user-attachments/assets/c32239de-f1ba-4aa8-82bb-c878ed009257" />
<img width="226" height="236" alt="newadditional" src="https://github.com/user-attachments/assets/68f4d658-9f65-4011-965a-c363ccebd36b" />

