### PR TITLE
Adds fill highlight mode for totems

### DIFF
--- a/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
+++ b/src/main/java/com/github/therealguru/totemfletching/TotemFletchingConfig.java
@@ -1,6 +1,8 @@
 package com.github.therealguru.totemfletching;
 
 import java.awt.Color;
+
+import com.github.therealguru.totemfletching.model.TotemHighlightMode;
 import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
@@ -28,16 +30,24 @@ public interface TotemFletchingConfig extends Config {
             description = "Draw the highlight over totems",
             section = sectionOverlays,
             position = 0)
-    default boolean renderTotemHighlight() {
-        return true;
+    default TotemHighlightMode renderTotemHighlight() {
+        return TotemHighlightMode.OUTLINE;
     }
+
+    @ConfigItem(
+            keyName = "totemFillAlpha",
+            name = "Totem Fill Opacity",
+            section = sectionOverlays,
+            description = "Opacity of the filled totem highlight (0-255)",
+            position = 1)
+    default int totemFillAlpha() { return 80; }
 
     @ConfigItem(
             keyName = "renderTotemText",
             name = "Show Totem Text",
             description = "Draw the text overlay over totems for animals and decorations",
             section = sectionOverlays,
-            position = 1)
+            position = 2)
     default boolean renderTotemText() {
         return true;
     }
@@ -47,7 +57,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Show Points Text",
             description = "Draw the text overlay over points",
             section = sectionOverlays,
-            position = 2)
+            position = 3)
     default boolean renderPoints() {
         return true;
     }
@@ -58,7 +68,7 @@ public interface TotemFletchingConfig extends Config {
             description =
                     "Whether to show the ent trails that need to be stepped on for bonus points",
             section = sectionOverlays,
-            position = 3)
+            position = 4)
     default boolean renderEntTrails() {
         return true;
     }
@@ -68,7 +78,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Highlight Correct Carving Choices",
             description = "Highlight which animals to select in the totem carving interface",
             section = sectionOverlays,
-            position = 4)
+            position = 5)
     default boolean highlightCorrectCarvingChoice() {
         return true;
     }
@@ -78,7 +88,7 @@ public interface TotemFletchingConfig extends Config {
             name = "Mask Incorrect Carving Choices",
             description = "Mask the incorrect animals in the totem carving interface",
             section = sectionOverlays,
-            position = 5)
+            position = 6)
     default boolean maskIncorrectCarvingChoice() {
         return true;
     }

--- a/src/main/java/com/github/therealguru/totemfletching/model/TotemHighlightMode.java
+++ b/src/main/java/com/github/therealguru/totemfletching/model/TotemHighlightMode.java
@@ -1,0 +1,8 @@
+package com.github.therealguru.totemfletching.model;
+
+public enum TotemHighlightMode
+{
+    NONE,
+    OUTLINE,
+    FILL
+}

--- a/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
+++ b/src/main/java/com/github/therealguru/totemfletching/overlay/TotemFletchingOverlay.java
@@ -3,6 +3,7 @@ package com.github.therealguru.totemfletching.overlay;
 import com.github.therealguru.totemfletching.TotemFletchingConfig;
 import com.github.therealguru.totemfletching.TotemFletchingPlugin;
 import com.github.therealguru.totemfletching.model.Totem;
+import com.github.therealguru.totemfletching.model.TotemHighlightMode;
 import com.github.therealguru.totemfletching.service.TotemService;
 import java.awt.*;
 import java.util.Map;
@@ -65,11 +66,31 @@ public class TotemFletchingOverlay extends Overlay {
     }
 
     private void renderTotemHighlight(Graphics2D graphics2D, Totem totem) {
-        if (!config.renderTotemHighlight()) return;
+
+        TotemHighlightMode mode = config.renderTotemHighlight();
+        if (mode == TotemHighlightMode.NONE) return;
 
         if (totem.hasTotemStarted()) {
             Shape shape = totem.getTotemGameObject().getClickbox();
             if (shape != null) {
+                final Color highlight = getTotemColor(totem);
+
+                if (mode == TotemHighlightMode.FILL) {
+                    final int alpha = config.totemFillAlpha();
+                    final Color fill = new Color(highlight.getRed(), highlight.getGreen(), highlight.getBlue(), alpha);
+
+                    graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                    final Composite oldComposite = graphics2D.getComposite();
+                    final Color oldColor = graphics2D.getColor();
+
+                    graphics2D.setComposite(AlphaComposite.SrcOver);
+                    graphics2D.setColor(fill);
+                    graphics2D.fill(shape);
+
+                    graphics2D.setColor(oldColor);
+                    graphics2D.setComposite(oldComposite);
+                }
+
                 OverlayUtil.renderPolygon(graphics2D, shape, getTotemColor(totem));
             }
         } else {


### PR DESCRIPTION
Adds a fill highlight mode option for totems. This allows users to choose between outline, fill, or no highlighting.

The opacity of the fill can be adjusted via configuration.

I kept running away before adding decorations to my totems and figured others might prefer having the whole totem highlighted instead of just the clickbox.

This is my first time contributing to something like this, please let me know if anything could be done better.

<img width="746" height="555" alt="image" src="https://github.com/user-attachments/assets/cf906afa-300f-4e2b-8d36-adc43472f3fd" />
<img width="1035" height="477" alt="image" src="https://github.com/user-attachments/assets/6d362c1e-d5ed-41b6-9b30-50559145ff1e" />
<img width="1037" height="538" alt="image" src="https://github.com/user-attachments/assets/c860a779-bba3-440a-8488-df0544cdf094" />
<img width="1035" height="445" alt="image" src="https://github.com/user-attachments/assets/0820567d-2e8c-4a86-b254-92bd399a43cc" />




